### PR TITLE
Fix schematronFile reference

### DIFF
--- a/build_schematron-validation.xml
+++ b/build_schematron-validation.xml
@@ -28,7 +28,7 @@
             <sequential>
                 <echo level="verbose">Validate '@{map.file}' with '${schematron.map.validation.file}'</echo>
                 <schematron
-                    schematronFile="${schematron.topics.file}"
+                    schematronFile="${schematron.map.validation.file}"
                     expectSuccess="true"
                     schematronProcessingEngine="${schematron.processing.engine}">
                     <fileset dir="${dita.temp.dir}">


### PR DESCRIPTION
In my first attempt of setting up the plugin, I had to update the value of `schematronFile` for the map task in the build.

