### PR TITLE
Change antlib reference to use <for> task

### DIFF
--- a/build_taskdef_ant-contrib.xml
+++ b/build_taskdef_ant-contrib.xml
@@ -6,7 +6,7 @@
 <project>
 
     <taskdef
-        resource="net/sf/antcontrib/antcontrib.properties">
+        resource="net/sf/antcontrib/antlib.xml">
         <classpath>
             <pathelement location="lib/ant-contrib-1.0b3.jar"/>
         </classpath>


### PR DESCRIPTION
Before I forget, one last thing - for now :-)

`antlib.xml` was required in place of `antlib.properties` (unaware of your setup at the moment, just saying it did not work for me).

With `antlib.properties` I got: `[taskdef] Could not load definitions from resource net/sf/antcontrib/antlib.properties`

With no expertise on my side:

- https://stackoverflow.com/questions/12407637/apache-ant-does-not-recognize-for-task-macro-although-i-have-added-ant-contri
- http://ant-contrib.sourceforge.net/tasks/index.html

Looking forward to using this in production!
François
